### PR TITLE
for photostim, we have thousands of scanimage files

### DIFF
--- a/BCI_analysis/io/io_python.py
+++ b/BCI_analysis/io/io_python.py
@@ -105,6 +105,9 @@ def read_sessionwise_npy(file_path):
                 'sampling_rate': data["sampling_rate"],
                 'all_si_filenames': data["all_si_filenames"],
                 'closed_loop_filenames': data["closed_loop_filenames"],
+                'all_si_frame_nums':data['all_si_frame_nums'],
+                'photon_counts':data['photon_counts'],
+                'f0_scalar':data['f0_scalar'],
             }
         
     return data_dict

--- a/BCI_analysis/io/io_suite2p.py
+++ b/BCI_analysis/io/io_suite2p.py
@@ -107,7 +107,8 @@ def suite2p_to_npy(suite2p_path,
                     F = np.load(os.path.join(session_path, "F.npy"), allow_pickle=True)
                     F0 = np.load(os.path.join(session_path, "F0.npy"), allow_pickle=True)
                     photon_counts_dict=np.load(os.path.join(session_path,'photon_counts.npy'),allow_pickle=True).tolist()
-                    f0_scalar = np.mean(np.load(os.path.join(session_path,'F0.npy')),1)                    
+                                    
+                    f0_scalar = np.percentile(F0[:,:int(F0.shape[1]/2)],10,axis = 1)                    
                     
                     if adjust_channel_offsets: # this is optional, might not be important
                         channel_offset_dict = np.load(os.path.join(session_path,'channel_offset.npy'),allow_pickle=True).tolist()

--- a/BCI_analysis/pipeline/pipeline_bpod.py
+++ b/BCI_analysis/pipeline/pipeline_bpod.py
@@ -301,6 +301,7 @@ def export_pybpod_files_core(bpod_session_dict,
                            'next_trial_index' : list(),
                            'scanimage_file_names':list(),
                            'scanimage_tiff_headers':list()}
+    skip_metadata = False
     for scanimage_fname, scanimage_timestamp,scanimage_metadata in zip(residual_filenames,residual_timestamps,residual_metadata):
         if type(scanimage_timestamp) == float:
             residual_tiff_files['triggered'].append(False)
@@ -328,7 +329,13 @@ def export_pybpod_files_core(bpod_session_dict,
         residual_tiff_files['previous_trial_index'].append( prev_trial_idx)
         residual_tiff_files['next_trial_index'].append( next_trial_idx)
         residual_tiff_files['scanimage_file_names'].append(scanimage_fname)
-        residual_tiff_files['scanimage_tiff_headers'].append(scanimage_metadata)
+        if 'slm' in scanimage_fname and not skip_metadata:
+            residual_tiff_files['scanimage_tiff_headers'].append(scanimage_metadata)
+            skip_metadata = True
+        elif 'slm' in scanimage_fname and skip_metadata:
+            residual_tiff_files['scanimage_tiff_headers'].append(None)
+        else:
+            residual_tiff_files['scanimage_tiff_headers'].append(scanimage_metadata)
     
     behavior_dict['residual_tiff_files'] = residual_tiff_files
     


### PR DESCRIPTION
saving their metadata inflates the bpod files.

We are now saving the metadata of only the first scanimage file that has 'slm' in it and has no bpod trial. - this should have all the necessary information (we'll still have the timing of them though)